### PR TITLE
b-form-select로 변경한 후 role이 제대로 업데이트 되지 않는 에러 발생.

### DIFF
--- a/frontend/src/views/base/Table.vue
+++ b/frontend/src/views/base/Table.vue
@@ -25,11 +25,11 @@
              :per-page="perPage">
       <template slot="role" slot-scope="data">
         <div v-if="(user.role === 'system')">
-          <b-form-select class="form-control" v-model="data.item.role" v-on:change="onChange(data.item)">
+          <select class="form-control" v-model="data.item.role" v-on:change="onChange(data.item)">
               <option value="user">user</option>
               <option value="admin">admin</option>
               <option value="system">system</option>
-          </b-form-select>
+          </select>
         </div>
         <div v-else>
           {{data.item.role}}


### PR DESCRIPTION
onChange를 호출할 때 select에서 선택한 role이 아니라 이전 role 데이터가 넘겨짐.
onChange에서 현재 선택한 row의 data.item과 select.value 모두 필요한 상황임.
다양하게 시도해보았으나(input hidden을 사용하려고 하였으나 vue에서는 사용 불가) 아직 답을 찾지 못해 select로 원복.