### PR TITLE
배포 환경 적용

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -14,7 +14,7 @@ var APIError = require('./helpers/APIError');
 var path = require('path');
 var appRoot = require('app-root-path');
 var favicon = require('serve-favicon');
-var debug = require('debug')('backend:app');
+var debug = require('debug')('api:app');
 
 var swaggerUi = require('swagger-ui-express');
 var swaggerDocument = require('./swagger.json');

--- a/backend/bin/www
+++ b/backend/bin/www
@@ -5,7 +5,7 @@
  */
 
 var app = require('../app');
-var debug = require('debug')('backend:server');
+var debug = require('debug')('api:server');
 var http = require('http');
 
 /**

--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+      {
+          name: "API",
+          script: "./bin/www",
+          env: {
+              PORT: 3000,
+              NODE_ENV: "development",
+              DEBUG: "api:*"
+          },
+          env_production: {
+              PORT: 3000,
+              NODE_ENV: "production",
+              DEBUG: "api:*"
+          }
+      }
+  ]
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "api",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "backend",
+  "name": "api",
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "DEBUG=backend:* nodemon ./bin/www",
+    "start": "pm2-dev start ecosystem.config.js",
+    "deploy": "npm install && pm2 startOrRestart ecosystem.config.js -i 2 --env production",
     "test": "NODE_ENV=test mocha --timeout 120000 --exit test/**/*.test.js"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "mysql": "2.15.0",
     "node-thumbnail": "^0.14.0",
     "nodemailer": "^4.6.4",
+    "pm2": "^3.5.0",
     "qs": "^6.5.2",
     "serve-favicon": "^2.3.2",
     "swagger-jsdoc": "^1.9.7",
@@ -46,7 +48,6 @@
     "mockgoose": "^8.0.1",
     "mongodb-topology-manager": "^2.1.0",
     "mongoose": "^5.5.5",
-    "nodemon": "^1.19.0",
     "should": "^13.2.3",
     "sinon": "^7.3.2",
     "sinon-as-promised": "^4.0.3",


### PR DESCRIPTION
### 주요 변경 사항
- nodemon 제거 및 pm2 적용
### 실행 방법
- 실행 in development
`npm run start`
- 실행 in production
`npm run deploy`

> pm2 글로벌로 설치시 pm2 관련 명령어를 쉽게 사용할 수 있습니다.
> `npm install -g pm2`