### PR TITLE
pm2 docker에서 실행 되도록 수정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "pm2-dev start ecosystem.config.js",
-    "deploy": "npm install && pm2-docker start ecosystem.config.js -i 2 --env production",
+    "deploy": "npm install && pm2 startOrRestart ecosystem.config.js -i 2 --env production",
+    "deploy:docker": "npm install && pm2-docker start ecosystem.config.js -i 2 --env production",
     "test": "NODE_ENV=test mocha --timeout 120000 --exit test/**/*.test.js"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "pm2-dev start ecosystem.config.js",
-    "deploy": "npm install && pm2 startOrRestart ecosystem.config.js -i 2 --env production",
+    "deploy": "npm install && pm2-docker start ecosystem.config.js -i 2 --env production",
     "test": "NODE_ENV=test mocha --timeout 120000 --exit test/**/*.test.js"
   },
   "dependencies": {


### PR DESCRIPTION
pm2 실행시 커맨드 라인으로 나오게 되어 데몬이 죽는 현상이 발생합니다.
pm2를 docker에서 실행하려고 하면 pm2-docker 명령으로 실행하면 문제가 해결됩니다. 